### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,17 @@ an elf parser and manipulation library in pure rust
 [dependencies]
 byteorder = "1"
 enum-primitive-derive = "0.1"
-num-traits = "^0.1"
+num-traits = "0.2.5"
 bitflags = "1.0.0"
-itertools = "0.6"
-rayon = "0.8.2"
-bit-vec = "0.4.4"
+itertools = "0.7.8"
+rayon = "1.0.1"
+bit-vec = "0.5.0"
 bloom = "0.3.2"
 fnv = "1.0.5"
-ordermap = "0.3.0"
+indexmap = "1.0.1"
 log = "0.4"
 env_logger = "0.5.10"
-pretty_env_logger = "0.1.1"
+pretty_env_logger = "0.2.3"
 clap = "2.28.0"
 glob = "0.2.11"
 ar = "0.6.0"
@@ -32,8 +32,8 @@ ar = "0.6.0"
 
 ## bin dependencies
 colored = "1"
-tempfile = "2.2.0"
-sha2 = "0.6"
+tempfile = "3.0.2"
+sha2 = "0.7.1"
 
 
 [[bin]]
@@ -51,4 +51,3 @@ path="bin/ld.rs"
 [[bin]]
 name="ldd"
 path="bin/ldd.rs"
-

--- a/bin/ld.rs
+++ b/bin/ld.rs
@@ -1,13 +1,13 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate elfkit;
-extern crate ordermap;
+extern crate indexmap;
 extern crate byteorder;
 extern crate env_logger;
 
 use std::env;
 use elfkit::{Elf, Header, types, symbol, relocation, section, Error, loader, dynamic};
 use elfkit::symbolic_linker::{SymbolicLinker};
-use self::ordermap::{OrderMap};
+use self::indexmap::{IndexMap};
 use std::collections::hash_map::{self,HashMap};
 use std::fs::OpenOptions;
 use std::os::unix::fs::PermissionsExt;
@@ -676,7 +676,7 @@ pub trait Collector {
 /// a dummy implementation of Collector which works for testing
 pub struct SimpleCollector {
     pub collected:  Collected,
-    sections: OrderMap<Vec<u8>, section::Section>,
+    sections: IndexMap<Vec<u8>, section::Section>,
 }
 
 impl Collector for SimpleCollector {
@@ -694,7 +694,7 @@ impl SimpleCollector {
 
     pub fn new(mut elf: Elf) -> SimpleCollector {
 
-        let mut sections = OrderMap::new();
+        let mut sections = IndexMap::new();
         if elf.sections.len() < 1 {
             sections.insert(Vec::new(), section::Section::default());
         } else {
@@ -779,7 +779,7 @@ impl SimpleCollector {
         sec.header.flags.remove(types::SectionFlags::GROUP);
 
         let (nu_shndx, nu_off) = match self.sections.entry(name.clone()) {
-            ordermap::Entry::Occupied(mut e) => {
+            indexmap::map::Entry::Occupied(mut e) => {
                 let i  = e.index();
                 let ov = match sec.content {
                     section::SectionContent::Raw(mut r) => {
@@ -804,7 +804,7 @@ impl SimpleCollector {
                 };
                 (i, ov)
             },
-            ordermap::Entry::Vacant(e) => {
+            indexmap::map::Entry::Vacant(e) => {
                 let i = e.index();
                 sec.name = name.clone();
                 sec.addrlock = false;
@@ -935,5 +935,3 @@ pub fn parse_ld_options() -> LdOptions{
 
     options
 }
-
-

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -8,7 +8,7 @@ use symbol;
 use section;
 use segment;
 
-use ordermap::{OrderMap};
+use indexmap::{IndexMap};
 use std::collections::hash_map::{HashMap};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std;
@@ -313,8 +313,8 @@ impl Elf {
         //original_size += 1;
 
 
-        let symtab_remap : OrderMap<usize, symbol::Symbol>
-            = OrderMap::from_iter(symtab_ls.into_iter().chain(symtab_gs.into_iter()));
+        let symtab_remap : IndexMap<usize, symbol::Symbol>
+            = IndexMap::from_iter(symtab_ls.into_iter().chain(symtab_gs.into_iter()));
 
         for sec in &mut self.sections {
             match sec.header.shtype {
@@ -439,8 +439,8 @@ impl Elf {
         for (shndx, sec)  in self.sections.iter_mut().enumerate().skip(1) {
             dbg_old_addresses.push(sec.header.addr);
 
-            trace!(" > {:<10.10}\t{}\t{}\t{}\t{}\t{}\t{:?}", 
-                     String::from_utf8_lossy(&sec.name), sec.header.size, poff, voff, 
+            trace!(" > {:<10.10}\t{}\t{}\t{}\t{}\t{}\t{:?}",
+                     String::from_utf8_lossy(&sec.name), sec.header.size, poff, voff,
                      current_load_segment_pstart,
                      current_load_segment_vstart,
                      current_load_segment_flags);
@@ -675,7 +675,7 @@ impl Elf {
 
 
 
-  
+
 
     //TODO this code isnt tested at all
     //TODO the warnings need to be emited when calling store_all instead

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 extern crate byteorder;
 #[macro_use] extern crate enum_primitive_derive;
 extern crate num_traits;
-extern crate ordermap;
+extern crate indexmap;
 #[macro_use] extern crate log;
 
 #[macro_use] pub mod utils;

--- a/src/symbolic_linker.rs
+++ b/src/symbolic_linker.rs
@@ -1,4 +1,4 @@
-extern crate ordermap;
+extern crate indexmap;
 
 use {Header, types, symbol, relocation, section, Error};
 use std;


### PR DESCRIPTION
The outdated requirements in elfkit were resulting in duplicate dependencies in my crate, so I decided to upgrade them. The only real change is that ordermap has been renamed to indexmap and moved `Entry` to a module.