### PR TITLE
Fix Strtab::insert panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -701,7 +701,7 @@ impl Elf {
             }
         }
 
-        Ok((r))
+        Ok(r)
     }
     pub fn insert_section(&mut self, at: usize, sec: Section) -> Result<(), Error> {
         self.sections.insert(at, sec);

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -188,6 +188,6 @@ impl Relocation {
 
         elf_write_u64!(eh, io, self.addend as u64)?;
 
-        Ok((8+8+8))
+        Ok(8+8+8)
     }
 }

--- a/src/strtab.rs
+++ b/src/strtab.rs
@@ -1,10 +1,8 @@
 use std::io::{Read, Write};
 use {Error, Header, SectionContent};
-use std::collections::hash_map::{Entry, HashMap};
 
 #[derive(Debug, Default, Clone)]
 pub struct Strtab {
-    hash: Option<HashMap<Vec<u8>, usize>>,
     data: Vec<u8>,
 }
 
@@ -15,32 +13,18 @@ impl Strtab {
     pub fn entsize(_: &Header) -> usize {
         1
     }
-    pub fn from_reader<R>(
-        mut io: R,
+    pub fn from_reader(
+        mut io: impl Read,
         _: Option<&SectionContent>,
         _: &Header,
-    ) -> Result<SectionContent, Error>
-    where
-        R: Read,
-    {
+    ) -> Result<SectionContent, Error> {
         let mut data = Vec::new();
         io.read_to_end(&mut data)?;
-        Ok(SectionContent::Strtab(Strtab{
-            hash: None,
-            data: data,
-        }))
+        Ok(SectionContent::Strtab(Strtab { data }))
     }
 
-    pub fn to_writer<W>(
-        &self,
-        mut io: W,
-        _: &Header,
-    ) -> Result<(usize), Error>
-    where
-        W: Write,
-    {
-        io.write(&self.data)?;
-        Ok(self.data.len())
+    pub fn to_writer(&self, mut io: impl Write, _: &Header) -> Result<usize, Error> {
+        Ok(io.write(&self.data)?)
     }
 
     pub fn get(&self, i: usize) -> Vec<u8> {
@@ -48,49 +32,101 @@ impl Strtab {
             println!("pointer {} into strtab extends beyond section size", i);
             return b"<corrupt>".to_vec();
         }
-        self.data[i..].split(|c| *c == 0).next().unwrap_or(&[0; 0]).to_vec()
+        self.data[i..]
+            .split(|&c| c == 0)
+            .next()
+            .unwrap_or(&[0; 0])
+            .to_vec()
     }
 
     pub fn insert(&mut self, ns: &[u8]) -> usize {
-
-        //special handling for null. for some reason rusts hashmap doesn't do that correctly
-        if self.data.len() < 1 {
-            self.data.push(0)
-        }
-        if ns.len() == 0 {
-            return 0;
-        }
-
-        //TODO this is less efficient than just scanning data, so it's kinda pointless
-        if self.hash == None {
-            let mut hash = HashMap::new();
-
-            let mut n = Vec::new();
-            let mut start = 0;
-            for i in 0..self.data.len() {
-                let c = self.data[i];
-                if c == 0 {
-                    for x in 0..self.data.len() {
-                        hash.insert(n[x..].to_vec(), start + x);
+        // If ns is already in our data, it takes up (ns.len() + 1) bytes.
+        if let Some(max_start) = self.data.len().checked_sub(ns.len() + 1) {
+            for start in 0..=max_start {
+                // We first check for ns, then check for the null terminator.
+                if self.data[start..].starts_with(ns) {
+                    if self.data[start + ns.len()] == 0 {
+                        return start;
                     }
-                    start = i + 1;
-                    n = Vec::new()
-                } else {
-                    n.push(c);
                 }
             }
-            self.hash = Some(hash);
         }
 
-        match self.hash.as_mut().unwrap().entry(ns.to_vec()) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                let i = self.data.len();
-                self.data.extend(ns);
-                self.data.extend(&[0; 1]);
-                entry.insert(i);
-                i
-            }
-        }
+        // No spot for ns, insert it (and the null terminator) at the end.
+        let i = self.data.len();
+        self.data.extend(ns);
+        self.data.push(0);
+        i
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_then_get() {
+        let ns1: &[u8] = b".text";
+        let ns2: &[u8] = b".data";
+        let mut strtab = Strtab { data: Vec::new() };
+
+        assert_eq!(strtab.insert(&[]), 0);
+        assert_eq!(strtab.insert(ns1), 1);
+        assert_eq!(strtab.insert(ns2), 2 + ns1.len());
+
+        assert_eq!(strtab.get(0), &[]);
+        assert_eq!(strtab.get(1), ns1);
+        assert_eq!(strtab.get(2 + ns1.len()), ns2);
+    }
+
+    #[test]
+    fn test_insert_suffix() {
+        let mut strtab = Strtab { data: Vec::new() };
+        assert_eq!(strtab.insert(b".text"), 0);
+
+        // inserting an existing suffix should not grow the data size
+        let old_size = strtab.data.len();
+        assert_eq!(strtab.insert(b"xt"), 3);
+        assert_eq!(strtab.data.len(), old_size);
+    }
+
+    #[test]
+    fn test_starting_data() {
+        let ns = b".text";
+        // Have the data initially be [NULL, ".text"]
+        let mut data = vec![0];
+        data.extend(ns);
+        data.push(0);
+
+        let mut strtab = Strtab { data };
+        assert_eq!(strtab.get(1), ns);
+        assert_eq!(strtab.insert(b".data"), 2 + ns.len());
+    }
+
+    #[test]
+    fn test_only_data() {
+        let ns: &[u8] = b".text";
+        // Have the data initially just be ".text"
+        let mut data = vec![];
+        data.extend(ns);
+        data.push(0);
+        let mut strtab = Strtab { data };
+        // The only value should be ".text"
+        assert_eq!(strtab.get(0), ns);
+        // Inserting the value again should change nothing.
+        assert_eq!(strtab.insert(ns), 0);
+        assert_eq!(strtab.get(0), ns);
+    }
+
+    #[test]
+    fn test_insert_prefix() {
+        // Have the data initially just be ".text"
+        let mut data = vec![];
+        data.extend(b".text");
+        data.push(0);
+
+        let mut strtab = Strtab { data };
+        // Inserting a prefix should not save any space
+        assert_eq!(strtab.insert(b".tex"), 6);
     }
 }


### PR DESCRIPTION
Right now  `Strtab::insert` will panic with and out-of-bounds slice if Strtab.data starts with a null byte, and Strtab::insert is called with a non-nil value.

This change fixes this bug in `Strtab::insert` by cleaning up the code, and removing an unnecessary vector. If you want me to just remove the hashtable logic entirely (as per the TODO) just let me know.

It also does a fixes a few warnings and adds a `.gitignore`, if you want me to split out these changes into a separate PR, just let me know.