### PR TITLE
avoid warnings in recent rust version

### DIFF
--- a/bin/ld.rs
+++ b/bin/ld.rs
@@ -624,7 +624,7 @@ impl Collected {
 
         let sh_index_symtab = self.elf.sections.len();
         let first_global_symtab = self.symtab.iter().enumerate()
-            .find(|&(_,s)|s.bind == types::SymbolBind::GLOBAL).map(|(i,_)|i).unwrap_or(0);;
+            .find(|&(_,s)|s.bind == types::SymbolBind::GLOBAL).map(|(i,_)|i).unwrap_or(0);
         self.elf.sections.push(section::Section::new(b".symtab".to_vec(), types::SectionType::SYMTAB,
         types::SectionFlags::empty(),
         section::SectionContent::Symbols(self.symtab),

--- a/src/dynamic.rs
+++ b/src/dynamic.rs
@@ -106,7 +106,7 @@ impl Dynamic {
         &self,
         mut io: W,
         eh: &Header,
-    ) -> Result<(usize), Error>
+    ) -> Result<usize, Error>
     where
         W: Write,
     {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -603,8 +603,8 @@ impl Elf {
         self.header.ehsize    = self.header.size() as u16;
         let mut hoff = (self.header.phnum as u64 * self.header.phentsize as u64) + self.header.ehsize as u64;
 
-        ///TODO this is shitty, because we need to replicate all the alignment code
-        ///also most of those sections dont actually need to be moved
+        //TODO this is shitty, because we need to replicate all the alignment code
+        //also most of those sections dont actually need to be moved
         for sec in &mut self.sections[1..] {
             if sec.header.addralign > 0 {
                 let oa = hoff % sec.header.addralign;
@@ -679,7 +679,7 @@ impl Elf {
 
     //TODO this code isnt tested at all
     //TODO the warnings need to be emited when calling store_all instead
-    pub fn remove_section(&mut self, at: usize) -> Result<(Section), Error> {
+    pub fn remove_section(&mut self, at: usize) -> Result<Section, Error> {
         let r = self.sections.remove(at);
 
         for sec in &mut self.sections {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -36,7 +36,7 @@ pub enum State {
         hash:    String,
         name:    String,
         elf:     Elf,
-        read:    RefCell<Box<ReadSeekSend>>,
+        read:    RefCell<Box<dyn ReadSeekSend>>,
         bloom:   BloomFilter,
         symbols: Vec<symbol::Symbol>,
     },
@@ -230,7 +230,7 @@ impl State {
         }
     }
 
-    fn make_object(name: String, io: RefCell<Box<ReadSeekSend>>) -> Result<State, Error> {
+    fn make_object(name: String, io: RefCell<Box<dyn ReadSeekSend>>) -> Result<State, Error> {
 
         let mut elf = Elf::from_reader(&mut *io.borrow_mut())?;
 

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -177,7 +177,7 @@ impl Relocation {
         &self,
         mut io: W,
         eh: &Header,
-    ) -> Result<(usize), Error>
+    ) -> Result<usize, Error>
     where
         W: Write,
     {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -170,7 +170,7 @@ impl Symbol {
         &self,
         mut io: W,
         eh: &Header,
-    ) -> Result<(usize), Error>
+    ) -> Result<usize, Error>
     where
         W: Write,
     {

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -143,7 +143,7 @@ fn layout_just_text() {
     let phdr_segments :Vec<&segment::SegmentHeader> = elf.segments.iter().filter(|x| x.phtype == types::SegmentType::PHDR).collect();
     assert_eq!(phdr_segments.len(), 1,
         "expecting exactly one phdr segment");
-    let phdr = phdr_segments.get(0).unwrap();;
+    let phdr = phdr_segments.get(0).unwrap();
 
     assert_eq!(phdr.offset, elf.header.phoff,
         "phdr.offset must be identical to elf header phoff");
@@ -155,7 +155,7 @@ fn layout_just_text() {
     assert_eq!(load_segments.len(), 1,
         "expect exactly one load segment");
 
-    let segment = load_segments.get(0).unwrap();;
+    let segment = load_segments.get(0).unwrap();
     assert_eq!(segment.offset,0,
         "first load segment must start at zero");
     assert_eq!(segment.vaddr, 0,
@@ -205,7 +205,7 @@ fn layout_just_bss() {
     let load_segments :Vec<&segment::SegmentHeader> = elf.segments.iter().filter(|x| x.phtype == types::SegmentType::LOAD).collect();
     assert_eq!(load_segments.len(), 1,
         "expect xactly one load segment");
-    let segment = load_segments.get(0).unwrap();;
+    let segment = load_segments.get(0).unwrap();
 
     assert!(segment.vaddr  <= elf.sections[1].header.addr,
         "first load segment must start at or before .bss");
@@ -252,8 +252,8 @@ fn layout_text_and_bss_1() {
     let load_segments :Vec<&segment::SegmentHeader> = elf.segments.iter().filter(|x| x.phtype == types::SegmentType::LOAD).collect();
     assert_eq!(load_segments.len(), 2,
         "expect exactly 2 load segments");
-    let segment0 = load_segments.get(0).unwrap();;
-    let segment1 = load_segments.get(1).unwrap();;
+    let segment0 = load_segments.get(0).unwrap();
+    let segment1 = load_segments.get(1).unwrap();
 
     assert_eq!(segment0.vaddr,0 ,
         "first load segment must start at 0");
@@ -303,9 +303,9 @@ fn layout_text_and_bss_2() {
     let load_segments :Vec<&segment::SegmentHeader> = elf.segments.iter().filter(|x| x.phtype == types::SegmentType::LOAD).collect();
     assert_eq!(load_segments.len(), 3,
         "expect exactly 3 load segments");
-    let segment0 = load_segments.get(0).unwrap();;
-    let segment1 = load_segments.get(1).unwrap();;
-    let segment2 = load_segments.get(2).unwrap();;
+    let segment0 = load_segments.get(0).unwrap();
+    let segment1 = load_segments.get(1).unwrap();
+    let segment2 = load_segments.get(2).unwrap();
 
     assert_eq!(segment0.vaddr, 0,
         "first load segment must start at 0");
@@ -468,7 +468,7 @@ fn layout_many_bss() {
         "expect exactly 5 segments");
 
     let load_segments :Vec<&segment::SegmentHeader> = elf.segments.iter().filter(|x| x.phtype == types::SegmentType::LOAD).collect();
-    let segment0 = load_segments.get(0).unwrap();;
+    let segment0 = load_segments.get(0).unwrap();
     assert!(!segment0.flags.contains(types::SegmentFlags::WRITABLE),
         "first load segment must NOT be writable");
 }


### PR DESCRIPTION
While tests are still passing, this patch changes the following things:

* remove a few obsolete paranthesis
* add a few implicit dyn keywords
* convert a doc comment to a regular one
* remove an obsolete semicolon

The following warnings appeared before the patch:

```
warning: unused doc comment
   --> src/elf.rs:606:9
    |
606 | /         ///TODO this is shitty, because we need to replicate all the alignment code
607 | |         ///also most of those sections dont actually need to be moved
    | |_____________________________________________________________________^
608 | /         for sec in &mut self.sections[1..] {
609 | |             if sec.header.addralign > 0 {
610 | |                 let oa = hoff % sec.header.addralign;
611 | |                 if oa != 0 {
...   |
614 | |             }
615 | |         }
    | |_________- rustdoc does not generate documentation for expressions
    |
    = note: `#[warn(unused_doc_comments)]` on by default

warning: unnecessary parentheses around type
   --> src/dynamic.rs:109:17
    |
109 |     ) -> Result<(usize), Error>
    |                 ^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

warning: unnecessary parentheses around type
   --> src/elf.rs:682:59
    |
682 |     pub fn remove_section(&mut self, at: usize) -> Result<(Section), Error> {
    |                                                           ^^^^^^^^^ help: remove these parentheses

warning: trait objects without an explicit `dyn` are deprecated
  --> src/loader.rs:39:30
   |
39 |         read:    RefCell<Box<ReadSeekSend>>,
   |                              ^^^^^^^^^^^^ help: use `dyn`: `dyn ReadSeekSend`
   |
   = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
   --> src/loader.rs:233:50
    |
233 |     fn make_object(name: String, io: RefCell<Box<ReadSeekSend>>) -> Result<State, Error> {
    |                                                  ^^^^^^^^^^^^ help: use `dyn`: `dyn ReadSeekSend`

warning: unnecessary parentheses around type
   --> src/relocation.rs:180:17
    |
180 |     ) -> Result<(usize), Error>
    |                 ^^^^^^^ help: remove these parentheses

warning: unnecessary parentheses around type
   --> src/symbol.rs:173:17
    |
173 |     ) -> Result<(usize), Error>
    |                 ^^^^^^^ help: remove these parentheses

warning: unnecessary trailing semicolon
   --> bin/ld.rs:627:91
    |
627 |             .find(|&(_,s)|s.bind == types::SymbolBind::GLOBAL).map(|(i,_)|i).unwrap_or(0);;
    |                                                                                           ^ help: remove this semicolon
    |
    = note: `#[warn(redundant_semicolon)]` on by default

    Finished release [optimized] target(s) in 0.03s 
```